### PR TITLE
replace module_path with current_list_dir

### DIFF
--- a/cmake/InstallTarget.cmake
+++ b/cmake/InstallTarget.cmake
@@ -5,7 +5,7 @@ write_basic_package_version_file(
 	COMPATIBILITY SameMajorVersion
 )
 configure_package_config_file(
-	"${CMAKE_MODULE_PATH}/${PROJECT_NAME}Config.cmake.in"
+	"${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Config.cmake.in"
 	"${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 	INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
 )


### PR DESCRIPTION
https://github.com/LouisCharlesC/safe/blob/2f24b6f1b4a4467abb68458deb77e82835ce5f92/cmake/InstallTarget.cmake#L7-L11

This uses `${CMAKE_MODULE_PATH}` which contains in my case a semicolon seperated list of files, and this [seems to be correct](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_PATH.html).

```text
| CMake Error: File /home/marcel/y_unic/build/tmp/work/cortexa7t2hf-neon-vfpv4-mut-linux-gnueabi/safe/1.0.1-r0/recipe-sysroot/usr/share/cmake/Modules/;/home/marcel/y_unic/build/tmp/work/cortexa7t2hf-neon-vfpv4-mut-linux-gnueabi/safe/1.0.1-r0/recipe-sysroot/usr/share/cmake/Modules/;/home/marcel/y_unic/build/tmp/work/cortexa7t2hf-neon-vfpv4-mut-linux-gnueabi/safe/1.0.1-r0/git/cmake/safeConfig.cmake.in does not exist.
| CMake Error at /home/marcel/y_unic/build/tmp/work/cortexa7t2hf-neon-vfpv4-mut-linux-gnueabi/safe/1.0.1-r0/recipe-sysroot-native/usr/share/cmake-3.15/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
|   configure_file Problem configuring file
| Call Stack (most recent call first):
|   cmake/InstallTarget.cmake:7 (configure_package_config_file)
|   CMakeLists.txt:17 (include)
```

Using `CMAKE_CURRENT_LIST_DIR` fixes it, because that variable contains the `cmake` subfolder which also contains the `safeConfig.cmake.in` file.